### PR TITLE
Table update 3col

### DIFF
--- a/src/lib/components/02-components/table/table-column.tsx
+++ b/src/lib/components/02-components/table/table-column.tsx
@@ -77,9 +77,6 @@ const TableColumn = ({ bgColor, children }: TableColumnProps) => {
             'border-y-2 border-y-transparent md:border-y-[0] border-r-transparent border-r-transparent md:border-x-2 border-x-transparent border-gradient':
               bgColor && !isFirstRow && !isLastRow,
             '!bg-white': bgColor,
-            // 'border-l-2': isMobile && bgColor && isFirstVisible,
-            // 'border-l-2 border-l-chateau':
-            //   isMobile && !isFirstRow && !isLastRow && isLastVisible,
             'border-r-2 border-x-chateau':
               (isMobile && isEven && !isLastPage) ||
               (isMobile && isLastPage && isBeforeLastRow),

--- a/src/lib/components/02-components/table/table-column.tsx
+++ b/src/lib/components/02-components/table/table-column.tsx
@@ -28,6 +28,7 @@ const TableColumn = ({ bgColor, children }: TableColumnProps) => {
       if (tableElement && rowElement) {
         // Calculate start and end indices for the current page
         const pageNumber = currentPage ? currentPage : 1;
+        const lastPage = Math.ceil(tableElement.rows.length / itemsPerPage);
         const startIndex = (pageNumber - 1) * itemsPerPage;
         const endIndex = pageNumber * itemsPerPage - 1;
 
@@ -42,8 +43,12 @@ const TableColumn = ({ bgColor, children }: TableColumnProps) => {
         const isFirstVisible = rowIndex === startIndex;
         const isLastVisible = rowIndex === endIndex;
         const isLastRow = rowIndex === rowCount - 1;
+        const isBeforeLastRow = rowIndex === rowCount - 2;
         const isFirstColumn = columnIndex === 0;
         const isFirstRow = rowIndex === 0;
+        const isEven = rowIndex % 2 === 0;
+        const isOdd = rowIndex % 2 !== 0;
+        const isLastPage = pageNumber === lastPage;
 
         // Determine if a border should be applied
         const shouldApplyBorder =
@@ -72,11 +77,18 @@ const TableColumn = ({ bgColor, children }: TableColumnProps) => {
             'border-y-2 border-y-transparent md:border-y-[0] border-r-transparent border-r-transparent md:border-x-2 border-x-transparent border-gradient':
               bgColor && !isFirstRow && !isLastRow,
             '!bg-white': bgColor,
-            'border-l-2': isMobile && bgColor && isFirstVisible,
-            'border-l-2 border-l-chateau':
-              isMobile && !isFirstRow && !isLastRow && isLastVisible,
+            // 'border-l-2': isMobile && bgColor && isFirstVisible,
+            // 'border-l-2 border-l-chateau':
+            //   isMobile && !isFirstRow && !isLastRow && isLastVisible,
             'border-r-2 border-x-chateau':
-              isMobile && !isFirstRow && !isLastRow && !isLastVisible,
+              (isMobile && isEven && !isLastPage) ||
+              (isMobile && isLastPage && isBeforeLastRow),
+            'border-l-2':
+              (isMobile && bgColor && isEven && !isLastPage) ||
+              (isMobile && bgColor && isLastPage && isBeforeLastRow),
+            'border-r-2':
+              isMobile && bgColor && isOdd && !isBeforeLastRow && !isLastPage,
+            // 'border-l-viola border-l-2': isLastPage && isBeforeLastRow,
           },
         );
 

--- a/src/lib/components/02-components/table/table-row.tsx
+++ b/src/lib/components/02-components/table/table-row.tsx
@@ -25,9 +25,7 @@ const TableRow = ({ bgColor, children }: TableRowProps) => {
         // Trying to retrieve the target element for the current page.
         const targetElementIndex = (currentPage - 1) * itemsPerPage;
         const targetElement = tableElement.rows[targetElementIndex];
-
         targetElement?.scrollIntoView({
-          behavior: 'smooth',
           inline: 'start',
           block: 'nearest',
         });

--- a/src/lib/components/02-components/table/table.stories.tsx
+++ b/src/lib/components/02-components/table/table.stories.tsx
@@ -15,8 +15,7 @@ export const Default = () => {
     <TableWrapper
       heading="Figma ipsum component variant main layer. Duplicate align figjam."
       subheading="Figma ipsum component variant main layer. Scale editor mask bullet flatten export team blur. Main prototype scrolling scale frame main distribute. Undo image vertical ipsum italic link layout community project arrow."
-      description="DISCLAIMER: Product comparison is based off of in-product capabilities and cross-portfolio integrations available from the same vendor as of Mar 1st, 2023. Comparisons do not include integrations with third-party vendors. Feature comparison is based off of each vendor’s most recent and modern version available as of Mar 1st, 2023. Information is based off of data collected from public websites and forums, analyst papers, and product datasheets as of Mar 1st, 2023."
-    >
+      description="DISCLAIMER: Product comparison is based off of in-product capabilities and cross-portfolio integrations available from the same vendor as of Mar 1st, 2023. Comparisons do not include integrations with third-party vendors. Feature comparison is based off of each vendor’s most recent and modern version available as of Mar 1st, 2023. Information is based off of data collected from public websites and forums, analyst papers, and product datasheets as of Mar 1st, 2023.">
       <TableRow>
         <TableColumn>
           <div>
@@ -62,8 +61,7 @@ export const Default = () => {
             height="30px"
             className="mx-auto"
             viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
+            xmlns="http://www.w3.org/2000/svg">
             <path
               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"
               fill="#003654"
@@ -76,8 +74,7 @@ export const Default = () => {
             height="30px"
             className="mx-auto"
             viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
+            xmlns="http://www.w3.org/2000/svg">
             <path
               d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
               fill="#a2a9ad"
@@ -90,8 +87,7 @@ export const Default = () => {
             height="30px"
             className="mx-auto"
             viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
+            xmlns="http://www.w3.org/2000/svg">
             <path
               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"
               fill="#a2a9ad"
@@ -119,8 +115,7 @@ export const Default = () => {
               height="30px"
               className="mx-auto"
               viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
+              xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"
                 fill="#003654"
@@ -139,8 +134,7 @@ export const Default = () => {
               height="30px"
               className="mx-auto"
               viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
+              xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M448 256c0-106-86-192-192-192V448c106 0 192-86 192-192zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
                 fill="#a2a9ad"
@@ -159,8 +153,7 @@ export const Default = () => {
               height="30px"
               className="mx-auto"
               viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
+              xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
                 fill="#a2a9ad"
@@ -177,7 +170,7 @@ export const Default = () => {
         <TableColumn>
           <div>
             <p>
-              <strong>Data Security Features</strong>
+              <strong>Before Last column</strong>
             </p>
             <br />
             <p>

--- a/src/lib/components/02-components/table/table.stories.tsx
+++ b/src/lib/components/02-components/table/table.stories.tsx
@@ -201,6 +201,41 @@ export const Default = () => {
           </p>
         </TableColumn>
       </TableRow>
+      <TableRow>
+        <TableColumn>
+          <div>
+            <p>
+              <strong>Last Column</strong>
+            </p>
+            <br />
+            <p>
+              Lorem ipsum dolor sit amet consectetur. Laoreet aliquet diam eu
+              commodo nisl pretium. Dictumst justo accumsan.
+            </p>
+          </div>
+        </TableColumn>
+        <TableColumn bgColor="#F5F6F6">
+          <p className="text-center">
+            <span className="text-h3 text-navy">AAA</span>
+            <br />
+            <span className="text-grey">Lorem ipsum dolor sit</span>
+          </p>
+        </TableColumn>
+        <TableColumn>
+          <p className="text-center">
+            <span className="text-h3 text-black">AAA</span>
+            <br />
+            <span className="text-grey">Lorem ipsum dolor sit</span>
+          </p>
+        </TableColumn>
+        <TableColumn>
+          <p className="text-center">
+            <span className="text-h3 text-black">AAA</span>
+            <br />
+            <span className="text-grey">Lorem ipsum dolor sit</span>
+          </p>
+        </TableColumn>
+      </TableRow>
     </TableWrapper>
   );
 };


### PR DESCRIPTION
# Ticket(s)

- Handle table on mobile when having an odd number of columns

## Purpose

**This PR does the following:**

- Handle table on mobile when having an odd number of columns
- Remove smooth scrolling (it's causing problems with column shifting after clicking on the pager)
- Add new column to story