### PR TITLE
Omg enablement: Adjust Language Drop-Down for Two Column Layout vs One Column.

### DIFF
--- a/src/lib/components/02-components/menus/secondary-menu/secondary-menu.tsx
+++ b/src/lib/components/02-components/menus/secondary-menu/secondary-menu.tsx
@@ -214,6 +214,7 @@ export default function SecondaryMenu({
             hidden: active !== index,
             'h-auto max-lg:static lg:bottom-[100%] lg:top-auto':
               onFooter && isLanguageSwitcher,
+            'lg:w-[380px]': isLanguageSwitcher,
           },
         )}
         onBlur={handleBlur}
@@ -259,7 +260,8 @@ export default function SecondaryMenu({
         <ul
           className={cn(
             'flex flex-1 flex-col bg-white py-sm lg:gap-md lg:rounded-m lg:p-md lg:shadow-md',
-            { 'max-lg:bg-transparent': onFooter && isLanguageSwitcher },
+            { 'max-lg:bg-transparent': onFooter && isLanguageSwitcher , 
+              'sm:grid sm:grid-cols-2': isLanguageSwitcher },
           )}
         >
           {item.below?.map(renderSubitem)}

--- a/src/lib/components/02-components/menus/secondary-menu/secondary-menu.tsx
+++ b/src/lib/components/02-components/menus/secondary-menu/secondary-menu.tsx
@@ -214,7 +214,7 @@ export default function SecondaryMenu({
             hidden: active !== index,
             'h-auto max-lg:static lg:bottom-[100%] lg:top-auto':
               onFooter && isLanguageSwitcher,
-            'lg:w-[380px]': isLanguageSwitcher,
+            'lg:w-[355px] right-[-95px]': isLanguageSwitcher,
           },
         )}
         onBlur={handleBlur}
@@ -261,7 +261,7 @@ export default function SecondaryMenu({
           className={cn(
             'flex flex-1 flex-col bg-white py-sm lg:gap-md lg:rounded-m lg:p-md lg:shadow-md',
             { 'max-lg:bg-transparent': onFooter && isLanguageSwitcher , 
-              'sm:grid sm:grid-cols-2': isLanguageSwitcher },
+              'lg:grid lg:grid-cols-2': isLanguageSwitcher },
           )}
         >
           {item.below?.map(renderSubitem)}


### PR DESCRIPTION
# Ticket(s)

- [Omg enablement: Adjust Language Drop-Down for Two Column Layout vs One Column.](https://app.asana.com/0/1203386530974194/1209345582889799)

## Purpose

**This PR does the following:**

- Changes the Language Switcher list to 2 columns.

### Functional Testing

- [ ] It will be tested once the FE has been updated with the new reference of the component:

![Screenshot 2025-02-27 at 10 38 11 AM](https://github.com/user-attachments/assets/accadf57-1eac-4b76-bc45-5a3cc2e8c99f)