### PR TITLE
Fix checkbox on white bg forms

### DIFF
--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -132,7 +132,12 @@
 
 .hubspot-form-wrapper .hs-fieldtype-booleancheckbox .input label,
 .hubspot-form-wrapper .hs-fieldtype-checkbox .input label {
-  @apply flex items-center gap-[5px] text-white;
+  @apply flex items-center gap-[5px];
+}
+
+.hubspot-form-wrapper:not(.hubspot-form-wrapper-white) .hs-fieldtype-booleancheckbox .input label,
+.hubspot-form-wrapper:not(.hubspot-form-wrapper-white) .hs-fieldtype-checkbox .input label {
+  @apply text-white;
 }
 
 .hubspot-form-wrapper


### PR DESCRIPTION
# Ticket(s)

- Hotfix: radio inputs are white on white background forms

## Purpose

**This PR does the following:**

- Fix text color for radio/checkboxes