### PR TITLE
Remove asterisk from optional fields

### DIFF
--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -116,16 +116,16 @@
 .hubspot-form-wrapper .hs-fieldtype-select {
   @apply flex flex-col;
 }
-.hubspot-form-wrapper .hs_name .input,
-.hubspot-form-wrapper .hs_email .input,
-.hubspot-form-wrapper .hs_custom_email .input,
-.hubspot-form-wrapper .hs_company .input,
-.hubspot-form-wrapper .hs_phone .input,
-.hubspot-form-wrapper .hs_jobtitle .input,
-.hubspot-form-wrapper .hs_firstname .input,
-.hubspot-form-wrapper .hs_lastname .input,
-.hubspot-form-wrapper .hs-fieldtype-text .input,
-.hubspot-form-wrapper .hs-fieldtype-select .input {
+.hubspot-form-wrapper .hs_name .input:has(:required),
+.hubspot-form-wrapper .hs_email .input:has(:required),
+.hubspot-form-wrapper .hs_custom_email .input:has(:required),
+.hubspot-form-wrapper .hs_company .input:has(:required),
+.hubspot-form-wrapper .hs_phone .input:has(:required),
+.hubspot-form-wrapper .hs_jobtitle .input:has(:required),
+.hubspot-form-wrapper .hs_firstname .input:has(:required),
+.hubspot-form-wrapper .hs_lastname .input:has(:required),
+.hubspot-form-wrapper .hs-fieldtype-text .input:has(:required),
+.hubspot-form-wrapper .hs-fieldtype-select .input:has(:required) {
   @apply relative before:absolute before:left-sm before:top-[12px] before:block before:text-teal before:content-["*"];
 }
 


### PR DESCRIPTION
# Ticket(s)

- [Remove asterisk from optional fields](https://app.asana.com/1/147662625849913/project/1203386530974194/task/1217689227121530?focus=true)

## Purpose

**This PR does the following:**

- Fixes the required-field asterisk (`.hubspot-form-wrapper` rule in `form.css`) showing on optional fields — it was gated on field-type/name classes (`hs-fieldtype-text`, `hs-fieldtype-select`, `hs_name`, etc.) instead of whether the field is actually required
- Adds `:has(:required)` to each selector so the asterisk only renders when the wrapped `input`/`select` carries the HTML `required` attribute

### Functional Testing

- [ ] Build and yalc-link this package into `forcepoint-nextjs`, run `npm run dev`
- [ ] Visit `/form/demo-request`
- [ ] Confirm optional fields (`dietary_requirements`, `form_message_field`) no longer show an asterisk
- [ ] Confirm required fields (name, email, company, phone, job title, etc.) still show the asterisk